### PR TITLE
Support multiparagraph blockquotes

### DIFF
--- a/src/testable.ts
+++ b/src/testable.ts
@@ -112,6 +112,10 @@ export function markdownBlockQuoteLevelFromRegExMatch(matchArray: RegExpMatchArr
         return 0;
 }
 
+export function isEmptyBlockQuote(text: string): boolean {
+    return text.match(/^(\s*>)+\s*$/) != null;
+}
+
 export function isMarkdownHeadingHash(text: string): boolean {
     return text.startsWith("#");
 }
@@ -304,6 +308,11 @@ export function getStartLine(lineAtFunc: (line: number) => TextLine, midLine: Te
         return midLine;        
     }
 
+    // If the current line is an empty blockquote line, it is a start line
+    if (isEmptyBlockQuote(midLine.text)) {
+        return midLine;
+    }
+
     // If the current line is a hash heading, the current line is a start point
     if (isMarkdownHeadingHash(midLine.text)) {
         return midLine;
@@ -317,6 +326,11 @@ export function getStartLine(lineAtFunc: (line: number) => TextLine, midLine: Te
     
     // If the prev line is empty, this line is the start
     if (prevLine.isEmptyOrWhitespace) {
+        return midLine;
+    }
+
+    // If the prev line is an empty blockquote line, this line is the start
+    if (isEmptyBlockQuote(prevLine.text)) {
         return midLine;
     }
 
@@ -358,6 +372,11 @@ export function getEndLine(lineAtFunc: (line: number) => TextLine, midLine: Text
         return midLine;
     }
 
+    // If the current line is an empty blockquote line, it is an end point
+    if (isEmptyBlockQuote(midLine.text)) {
+        return midLine;
+    }
+
     // If the current line is a hash it is a end point
     if (isMarkdownHeadingHash(midLine.text)) {
         return midLine;
@@ -378,6 +397,11 @@ export function getEndLine(lineAtFunc: (line: number) => TextLine, midLine: Text
 
     // if the next line is empty, this line is the end
     if (nextLine.isEmptyOrWhitespace) {
+        return midLine;
+    }
+
+    // If the next line is an empty blockquote line, this line is the end
+    if (isEmptyBlockQuote(nextLine.text)) {
         return midLine;
     }
 

--- a/testUnit/after.md
+++ b/testUnit/after.md
@@ -41,6 +41,23 @@ This is a Header Made With Dashes And It is Exactly 70 Characters Long
    > > be their own paragraph and therefore require their own reflow
    > > action.
 
+ > This is a big blockquote with multiple paragraphs inside of it.
+ > Some lines may be longer than the preferredLineLength, while others
+ > aren't.
+ > 
+ > The multiple paragraphs are not separated by an empty line, but by
+ > an empty blockquote line, which is a line with the blockquote start
+ > character (`>`) followed only by zero or more spaces.
+ > 
+ > > This is a nested blockquote with no empty line between it and the
+ > > previous blockquote.  It should be reflowed as a separate
+ > > paragraph as well.  Its formatting should also be fixed so that
+ > > the blockquote characters are alinged properly.
+ > > 
+ > > The level 2 blockquote also has two paragraphs in it, which are
+ > > separated by an empty level 2 blockquote line.  It should be
+ > > reflowed as two separate paragraphs as well.
+
 `{"settings": {"doubleSpaceBetweenSentences":false }}`
 
 This is a paragraph with several sentences. It starts out with two or

--- a/testUnit/befor.md
+++ b/testUnit/befor.md
@@ -30,6 +30,19 @@ This is a Header Made With Dashes And It is Exactly 70 Characters Long
    >>blockquotes are handled too by the reflowMarkdown extension, but they are considered to be their own
    >   >  paragraph and therefore require their own reflow action. 
 
+ > This is a big blockquote with multiple paragraphs inside of it. Some lines may be longer than
+ > the preferredLineLength, while others aren't.
+ >
+ > The multiple paragraphs are not separated by an empty line, but by an empty blockquote line, which is a
+ > line with the blockquote start character (`>`) followed only by zero or more spaces.
+ >
+ > > This is a nested blockquote with no empty line between it and the previous blockquote.  It
+ >> should be reflowed as a separate paragraph as well. Its formatting should also be fixed so
+ >>that the blockquote characters are alinged properly.
+ > >
+ > > The level 2 blockquote also has two paragraphs in it, which are separated by an empty level
+ > > 2 blockquote line. It should be reflowed as two separate paragraphs as well.
+
 `{"settings": {"doubleSpaceBetweenSentences":false }}`
 
 This is a paragraph with several sentences.  It starts out with two or more spaces between each sentence.    When it 


### PR DESCRIPTION
Added a small function `isEmptyBlockquote` to check if a line is an empty blockquote, and used it with calls after each check for empty lines in the `getStartLine` and `getEndLine` functions. Also modified the `befor.md` and `after.md` files with multiparagraph blockquote cases.

A note: empty blockquote lines are left with a trailing space, since it is included in the indent string. 